### PR TITLE
fix: injection mechanism for TemplateRef and ViewContainerRef

### DIFF
--- a/libs/route-config/src/lib/route-data-has/route-data-has.directive.ts
+++ b/libs/route-config/src/lib/route-data-has/route-data-has.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, OnInit, TemplateRef } from '@angular/core';
+import { Directive, Input, OnInit, TemplateRef, ViewContainerRef } from '@angular/core';
 import { RouteDataHasService } from './route-data-has.service';
 
 @Directive({
@@ -23,9 +23,13 @@ export class RouteDataHasDirective<CThen, CElse, RouteTags extends string = stri
     this.routeDataHasService.setElseTemplate(elseTemplate);
   }
 
-  constructor(private routeDataHasService: RouteDataHasService<CThen, CElse, RouteTags>) {}
+  constructor(
+    private template: TemplateRef<CThen>,
+    private viewContainer: ViewContainerRef,
+    private routeDataHasService: RouteDataHasService<CThen, CElse, RouteTags>
+  ) {}
 
   ngOnInit(): void {
-    this.routeDataHasService.init();
+    this.routeDataHasService.init(this.template, this.viewContainer);
   }
 }

--- a/libs/route-config/src/lib/route-data-has/route-data-has.service.spec.ts
+++ b/libs/route-config/src/lib/route-data-has/route-data-has.service.spec.ts
@@ -39,7 +39,7 @@ describe('RouteDataHasServiceService', () => {
     clear.mockReset();
     createEmbeddedView.mockClear();
 
-    service = new RouteDataHasService(routeConfigService, templateRef, viewContainerRef);
+    service = new RouteDataHasService(routeConfigService);
 
     service.setPropName('testProp');
     service.setTags('testTag');
@@ -62,7 +62,7 @@ describe('RouteDataHasServiceService', () => {
 
     routeConfig.next([]);
 
-    service.init();
+    service.init(templateRef, viewContainerRef);
 
     expect(clear).toHaveBeenCalledTimes(1);
   });
@@ -75,7 +75,7 @@ describe('RouteDataHasServiceService', () => {
 
     routeConfig.next([]);
 
-    service.init();
+    service.init(templateRef, viewContainerRef);
 
     expect(createEmbeddedView).toHaveBeenCalledTimes(1);
     expect(createEmbeddedView).toHaveBeenCalledWith(elseTemplateRef);
@@ -89,7 +89,7 @@ describe('RouteDataHasServiceService', () => {
 
     routeConfig.next(['testTag']);
 
-    service.init();
+    service.init(templateRef, viewContainerRef);
 
     expect(clear).toHaveBeenCalledTimes(1);
     expect(createEmbeddedView).toHaveBeenCalledTimes(1);
@@ -104,7 +104,7 @@ describe('RouteDataHasServiceService', () => {
 
     routeConfig.next(['testTag']);
 
-    service.init();
+    service.init(templateRef, viewContainerRef);
 
     expect(clear).toHaveBeenCalledTimes(1);
     expect(createEmbeddedView).toHaveBeenCalledTimes(1);
@@ -125,7 +125,7 @@ describe('RouteDataHasServiceService', () => {
 
     routeConfig.next([]);
 
-    service.init();
+    service.init(templateRef, viewContainerRef);
 
     expect(clear).toHaveBeenCalledTimes(1);
     expect(createEmbeddedView).toHaveBeenCalledTimes(1);
@@ -155,7 +155,7 @@ describe('RouteDataHasServiceService', () => {
     routeConfig.testProp.next(['testTag']);
     routeConfig.anotherTestProp.next(['notTestTag']);
 
-    service.init();
+    service.init(templateRef, viewContainerRef);
 
     expect(clear).toHaveBeenCalledTimes(1);
     expect(createEmbeddedView).toHaveBeenCalledTimes(1);
@@ -176,7 +176,7 @@ describe('RouteDataHasServiceService', () => {
 
     routeConfig.next(['notTestTag']);
 
-    service.init();
+    service.init(templateRef, viewContainerRef);
 
     expect(clear).toHaveBeenCalledTimes(1);
     expect(createEmbeddedView).toHaveBeenCalledTimes(1);

--- a/libs/route-config/src/lib/route-data-has/route-data-has.service.ts
+++ b/libs/route-config/src/lib/route-data-has/route-data-has.service.ts
@@ -12,6 +12,8 @@ export class RouteDataHasService<
   RoutePropNames extends string = string
 > implements OnDestroy
 {
+  private template!: TemplateRef<CThen>;
+  private viewContainer!: ViewContainerRef;
   private tags$ = new BehaviorSubject<RouteTags[]>([]);
   private propName$ = new BehaviorSubject<RoutePropNames | undefined>(undefined);
   private elseTemplate$ = new BehaviorSubject<TemplateRef<CElse> | null>(null);
@@ -29,11 +31,11 @@ export class RouteDataHasService<
   );
 
   private readonly createView$ = combineLatest([this.display$, this.elseTemplate$]).pipe(
-    tap(() => this.entry.clear()),
+    tap(() => this.viewContainer.clear()),
     tap(([show, elseTemplate]) =>
       show
-        ? void this.entry.createEmbeddedView(this.template)
-        : void (elseTemplate && this.entry.createEmbeddedView(elseTemplate))
+        ? void this.viewContainer.createEmbeddedView(this.template)
+        : void (elseTemplate && this.viewContainer.createEmbeddedView(elseTemplate))
     )
   );
 
@@ -50,13 +52,11 @@ export class RouteDataHasService<
     this.elseTemplate$.next(elseTemplate);
   }
 
-  constructor(
-    private routeConfigService: RouteConfigService<string, string>,
-    private template: TemplateRef<CThen>,
-    private entry: ViewContainerRef
-  ) {}
+  constructor(private routeConfigService: RouteConfigService<string, string>) {}
 
-  init() {
+  init(template: TemplateRef<CThen>, viewContainer: ViewContainerRef) {
+    this.template = template;
+    this.viewContainer = viewContainer;
     this.createView$.pipe(takeUntil(this.destroy$)).subscribe();
   }
 

--- a/libs/route-config/src/lib/route-tag/route-tag.directive.ts
+++ b/libs/route-config/src/lib/route-tag/route-tag.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, OnInit, TemplateRef } from '@angular/core';
+import { Directive, Input, OnInit, TemplateRef, ViewContainerRef } from '@angular/core';
 import { RouteDataHasService } from '../route-data-has/route-data-has.service';
 
 @Directive({ selector: '[tdRouteTag]', providers: [RouteDataHasService] })
@@ -14,11 +14,13 @@ export class RouteTagDirective<CThen, CElse, RouteTags extends string = string> 
   }
 
   constructor(
+    private template: TemplateRef<CThen>,
+    private viewContainer: ViewContainerRef,
     private routeDataHasService: RouteDataHasService<CThen, CElse, RouteTags, 'routeTags'>
   ) {}
 
   ngOnInit(): void {
     this.routeDataHasService.setPropName('routeTags');
-    this.routeDataHasService.init();
+    this.routeDataHasService.init(this.template, this.viewContainer);
   }
 }


### PR DESCRIPTION
## Bug

Fixed injection mechanism for `ViewContainerRef` (move to `RouteDataHasService:init` call)
Moved injection of `TemplateRef` to `RouteDataHasService:init` call as well
