### PR TITLE
feat: addItem, keys and entries initial implementation

### DIFF
--- a/apps/showcase-e2e/src/integration/cypress-indexedDB-helper.spec.ts
+++ b/apps/showcase-e2e/src/integration/cypress-indexedDB-helper.spec.ts
@@ -1,106 +1,111 @@
 describe(`@this-dot/cypress-indexeddb`, () => {
   beforeEach(() => {
     cy.clearIndexedDb('FORM_CACHE');
-    cy.clearIndexedDb('ADD_ITEM_KEYS_ENTRIES');
-    cy.openIndexedDb('FORM_CACHE')
-      .as('formCacheDB')
-      .createObjectStore('keyvaluepairs')
-      .as('objectStore');
+    cy.openIndexedDb('FORM_CACHE').as('formCacheDB');
   });
 
-  it(`can add items without providing keys and retrieve keys and values`, () => {
-    cy.openIndexedDb('ADD_ITEM_KEYS_ENTRIES')
-      .createObjectStore('test_add_item', { autoIncrement: true })
-      .as('test_add_item')
-      .addItem('test')
-      .addItem({ test: 'object' })
-      .addItem(1337);
+  describe(`key-value pair based databases`, () => {
+    beforeEach(() => {
+      cy.getIndexedDb('@formCacheDB').createObjectStore('keyvaluepairs').as('objectStore');
+    });
 
-    cy.getStore('@test_add_item').keys().should('have.length', 3).and('deep.equal', [1, 2, 3]);
+    it(`entering data into the form saves it to the indexedDb`, () => {
+      cy.visit('/cypress-helpers');
 
-    cy.getStore('@test_add_item')
-      .entries()
-      .should('have.length', 3)
-      .and('deep.equal', ['test', { test: 'object' }, 1337]);
-  });
+      cy.get('#firstName').should('be.visible').type('Hans');
+      cy.get('#lastName').should('be.visible').type('Gruber');
+      cy.get('#country').should('be.visible').type('Germany');
+      cy.get('#city').should('be.visible').type('Berlin');
 
-  it(`entering data into the form saves it to the indexedDb`, () => {
-    cy.visit('/cypress-helpers');
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.log('Waiting for the debounceTime to start a db write').wait(1100);
 
-    cy.get('#firstName').should('be.visible').type('Hans');
-    cy.get('#lastName').should('be.visible').type('Gruber');
-    cy.get('#country').should('be.visible').type('Germany');
-    cy.get('#city').should('be.visible').type('Berlin');
+      cy.getStore('@objectStore').readItem('user_form').should('deep.equal', {
+        firstName: 'Hans',
+        lastName: 'Gruber',
+        country: 'Germany',
+        city: 'Berlin',
+        address: '',
+        addressOptional: '',
+      });
+    });
 
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.log('Waiting for the debounceTime to start a db write').wait(1100);
+    it(`when the indexedDb is deleted manually and then the page reloaded, the form does not populate`, () => {
+      cy.visit('/cypress-helpers');
 
-    cy.getStore('@objectStore').readItem('user_form').should('deep.equal', {
-      firstName: 'Hans',
-      lastName: 'Gruber',
-      country: 'Germany',
-      city: 'Berlin',
-      address: '',
-      addressOptional: '',
+      cy.get('#firstName').should('be.visible').type('Hans');
+      cy.get('#lastName').should('be.visible').type('Gruber');
+      cy.get('#country').should('be.visible').type('Germany');
+      cy.get('#city').should('be.visible').type('Berlin');
+
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.log('Waiting for the debounceTime to start a db write').wait(1100);
+
+      cy.log('user manually clears the IndexedDb')
+        .getStore('@objectStore')
+        .deleteItem('user_form')
+        .keys()
+        .should('have.length', 0);
+      cy.reload();
+
+      cy.get('#firstName').should('be.visible').and('have.value', '');
+      cy.get('#lastName').should('be.visible').and('have.value', '');
+      cy.get('#country').should('be.visible').and('have.value', '');
+      cy.get('#city').should('be.visible').and('have.value', '');
+    });
+
+    it(`when there is relevant data in the indexedDb, the form gets populated when the page opens`, () => {
+      cy.getStore('@objectStore').createItem('user_form', {
+        firstName: 'John',
+        lastName: 'McClane',
+        country: 'USA',
+        city: 'New York',
+      });
+
+      cy.visit('/cypress-helpers');
+
+      cy.get('#firstName').should('be.visible').and('have.value', 'John');
+      cy.get('#lastName').should('be.visible').and('have.value', 'McClane');
+      cy.get('#country').should('be.visible').and('have.value', 'USA');
+      cy.get('#city').should('be.visible').and('have.value', 'New York');
+    });
+
+    it(`submitting the form clears the indexedDb`, () => {
+      cy.getStore('@objectStore').createItem('user_form', {
+        firstName: 'John',
+        lastName: 'McClane',
+        country: 'USA',
+        city: 'New York',
+      });
+
+      cy.visit('/cypress-helpers');
+
+      cy.get('#address').type('23rd Street 12');
+      cy.get(`[data-test-id="submit button"]`).should('be.visible').and('not.be.disabled').click();
+
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.log('Waiting for the save event and DB write to occur').wait(1100);
+
+      cy.getStore('@objectStore').readItem('user_form').should('be.undefined');
     });
   });
 
-  it(`when the indexedDb is deleted manually and then the page reloaded, the form does not populate`, () => {
-    cy.visit('/cypress-helpers');
-
-    cy.get('#firstName').should('be.visible').type('Hans');
-    cy.get('#lastName').should('be.visible').type('Gruber');
-    cy.get('#country').should('be.visible').type('Germany');
-    cy.get('#city').should('be.visible').type('Berlin');
-
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.log('Waiting for the debounceTime to start a db write').wait(1100);
-
-    cy.log('user manually clears the IndexedDb')
-      .getStore('@objectStore')
-      .deleteItem('user_form')
-      .keys()
-      .should('have.length', 0);
-    cy.reload();
-
-    cy.get('#firstName').should('be.visible').and('have.value', '');
-    cy.get('#lastName').should('be.visible').and('have.value', '');
-    cy.get('#country').should('be.visible').and('have.value', '');
-    cy.get('#city').should('be.visible').and('have.value', '');
-  });
-
-  it(`when there is relevant data in the indexedDb, the form gets populated when the page opens`, () => {
-    cy.getStore('@objectStore').createItem('user_form', {
-      firstName: 'John',
-      lastName: 'McClane',
-      country: 'USA',
-      city: 'New York',
+  describe(`addItem, keys and entries`, () => {
+    beforeEach(() => {
+      cy.getIndexedDb('@formCacheDB')
+        .createObjectStore('test_add_item', { autoIncrement: true })
+        .as('test_add_item');
     });
 
-    cy.visit('/cypress-helpers');
+    it(`can add items without providing keys and retrieve keys and values`, () => {
+      cy.getStore('@test_add_item').addItem('test').addItem({ test: 'object' }).addItem(1337);
 
-    cy.get('#firstName').should('be.visible').and('have.value', 'John');
-    cy.get('#lastName').should('be.visible').and('have.value', 'McClane');
-    cy.get('#country').should('be.visible').and('have.value', 'USA');
-    cy.get('#city').should('be.visible').and('have.value', 'New York');
-  });
+      cy.getStore('@test_add_item').keys().should('have.length', 3).and('deep.equal', [1, 2, 3]);
 
-  it(`submitting the form clears the indexedDb`, () => {
-    cy.getStore('@objectStore').createItem('user_form', {
-      firstName: 'John',
-      lastName: 'McClane',
-      country: 'USA',
-      city: 'New York',
+      cy.getStore('@test_add_item')
+        .entries()
+        .should('have.length', 3)
+        .and('deep.equal', ['test', { test: 'object' }, 1337]);
     });
-
-    cy.visit('/cypress-helpers');
-
-    cy.get('#address').type('23rd Street 12');
-    cy.get(`[data-test-id="submit button"]`).should('be.visible').and('not.be.disabled').click();
-
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.log('Waiting for the save event and DB write to occur').wait(1100);
-
-    cy.getStore('@objectStore').readItem('user_form').should('be.undefined');
   });
 });

--- a/apps/showcase-e2e/src/support/namespace.ts
+++ b/apps/showcase-e2e/src/support/namespace.ts
@@ -11,11 +11,17 @@ declare namespace Cypress {
     clearIndexedDb(databaseName: string): void;
     openIndexedDb(databaseName: string, version?: number): Chainable<IDBDatabase>;
     getIndexedDb(databaseName: string): Chainable<IDBDatabase>;
-    createObjectStore(storeName: string): Chainable<IDBObjectStore>;
+    createObjectStore(
+      storeName: string,
+      options?: IDBObjectStoreParameters
+    ): Chainable<IDBObjectStore>;
     getStore(storeName: string): Chainable<IDBObjectStore>;
     createItem(key: string, value: unknown): Chainable<IDBObjectStore>;
     readItem<T = unknown>(key: IDBValidKey | IDBKeyRange): Chainable<T>;
     updateItem(key: string, value: unknown): Chainable<IDBObjectStore>;
     deleteItem(key: string): Chainable<IDBObjectStore>;
+    addItem<T = unknown>(value: T): Chainable<IDBObjectStore>;
+    keys(): Chainable<IDBValidKey[]>;
+    entries<T = unknown>(): Chainable<T[]>;
   }
 }

--- a/libs/cypress-indexeddb/README.md
+++ b/libs/cypress-indexeddb/README.md
@@ -105,8 +105,8 @@ You can also pass an optional options parameter to configure your object store. 
 
 ```typescript
 cy.getIndexedDb('@database')
-  .createObjectStore('example_store', { autoIncrement: true })
-  .as('exampleStore');
+  .createObjectStore('example_autoincrement_store', { autoIncrement: true })
+  .as('exampleAutoincrementStore');
 ```
 
 You can retrieve the saved object store using the `cy.getStore('@exampleStore')`;
@@ -126,8 +126,6 @@ cy.getStore('@exampleStore')
   .createItem('example3', { exampleKey: 1337 });
 ```
 
-// TODO: addItem, keys and entries
-
 The `readItem` method yields the value of the provided key, or undefined if it does not exist. You can chain assertions from this method. If you use TypeScript, you can set the type of the returned value.
 
 ```typescript
@@ -136,6 +134,34 @@ cy.getStore('@exampleStore').readItem<string[]>('example2').should('have.length'
 cy.getStore('@exampleStore')
   .readItem<number>('example3')
   .should('have.property', 'exampleKey', 1337);
+```
+
+#### How to handle Object Stores with autoIncrement?
+
+When you need to manipulate or assert data stored in an Object Store, that was set up with `{ autoIncrement: true }`, you have the following commands at your disposal: `addItem`, `keys` and `entries`.
+
+The `addItem` method stores the provided value into the Object Store at a new index
+
+```typescript
+cy.getStore('@exampleAutoincrementStore').addItem('test').addItem({ test: 'object' }).addItem(1337);
+```
+
+The `keys` method returns an `IDBValidKey[]`. You can assert the results using the `.should()` method.
+
+```typescript
+cy.getStore('@exampleAutoincrementStore')
+  .keys()
+  .should('have.length', 3)
+  .and('deep.equal', [1, 2, 3]);
+```
+
+The `entries` method returns all the values that are stored in order. You can assert the results using the `.should()` method.
+
+```typescript
+cy.getStore('@exampleAutoincrementStore')
+  .entries()
+  .should('have.length', 3)
+  .and('deep.equal', ['test', { test: 'object' }, 1337]);
 ```
 
 ---

--- a/libs/cypress-indexeddb/README.md
+++ b/libs/cypress-indexeddb/README.md
@@ -44,12 +44,18 @@ It supports:
           clearIndexedDb(databaseName: string): void;
           openIndexedDb(databaseName: string, version?: number): Chainable<IDBDatabase>;
           getIndexedDb(databaseName: string): Chainable<IDBDatabase>;
-          createObjectStore(storeName: string): Chainable<IDBObjectStore>;
+          createObjectStore(
+            storeName: string,
+            options?: IDBObjectStoreParameters
+          ): Chainable<IDBObjectStore>;
           getStore(storeName: string): Chainable<IDBObjectStore>;
           createItem(key: string, value: unknown): Chainable<IDBObjectStore>;
           readItem<T = unknown>(key: IDBValidKey | IDBKeyRange): Chainable<T>;
           updateItem(key: string, value: unknown): Chainable<IDBObjectStore>;
           deleteItem(key: string): Chainable<IDBObjectStore>;
+          addItem<T = unknown>(value: T): Chainable<IDBObjectStore>;
+          keys(): Chainable<IDBValidKey[]>;
+          entries<T = unknown>(): Chainable<T[]>;
         }
       }
       ```
@@ -95,6 +101,14 @@ You can chain off the `createObjectStore('storeName')` method from methods that 
 cy.getIndexedDb('@database').createObjectStore('example_store').as('exampleStore');
 ```
 
+You can also pass an optional options parameter to configure your object store. For example, you can create an object store with `autoIncrement` with the following command:
+
+```typescript
+cy.getIndexedDb('@database')
+  .createObjectStore('example_store', { autoIncrement: true })
+  .as('exampleStore');
+```
+
 You can retrieve the saved object store using the `cy.getStore('@exampleStore')`;
 
 #### How to make CRUD operations on an Object Store?
@@ -111,6 +125,8 @@ cy.getStore('@exampleStore')
   .createItem('example2', ['testValue', 'testValue2'])
   .createItem('example3', { exampleKey: 1337 });
 ```
+
+// TODO: addItem, keys and entries
 
 The `readItem` method yields the value of the provided key, or undefined if it does not exist. You can chain assertions from this method. If you use TypeScript, you can set the type of the returned value.
 

--- a/libs/cypress-indexeddb/package.json
+++ b/libs/cypress-indexeddb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@this-dot/cypress-indexeddb",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A Cypress.io helper library for reading and manipulating data inside IndexedDB",
   "license": "MIT",
   "author": "This Dot Labs",

--- a/libs/cypress-indexeddb/src/lib/alias-setup.ts
+++ b/libs/cypress-indexeddb/src/lib/alias-setup.ts
@@ -1,7 +1,19 @@
 import { isIDBDatabase, isIDBObjectStore } from './helpers';
 
 const STORES = new Map<string, IDBObjectStore>();
+/**
+ * When we save a database with an alias, it saves the actual version that database was opened with.
+ * This prevents the `createObjectStore` method to create more than one store on any given database.
+ * That is why we set the database instance internally every time we create a database version update.
+ * When we do a version update, we don't have the database alias, only the database name. These two
+ * Map objects help resolve the proper database using an alias and internally a database name.
+ */
 const DATABASES = new Map<string, IDBDatabase>();
+const DATABASE_ALIASES = new Map<string, string>();
+
+export function setDatabaseInternal(databaseName: string, database: IDBDatabase): void {
+  DATABASES.set(databaseName, database);
+}
 
 type IDBItemType = 'store' | 'database';
 
@@ -14,7 +26,8 @@ export function overrideAs(
     STORES.set(alias, subject);
     return subject;
   } else if (isIDBDatabase(subject)) {
-    DATABASES.set(alias, subject);
+    DATABASE_ALIASES.set(alias, subject.name);
+    DATABASES.set(subject.name, subject);
     return subject;
   } else {
     return originalAs(subject, alias);
@@ -24,7 +37,7 @@ export const getDatabase = getIDBItem('database');
 export const getStore = getIDBItem('store');
 
 function getIDBItem(type: IDBItemType): (alias: string) => Promise<IDBDatabase | IDBObjectStore> {
-  const map = type === 'store' ? STORES : DATABASES;
+  const map = type === 'store' ? STORES : DATABASE_ALIASES;
   return (alias: string) => {
     let error: any;
     const log = Cypress.log({
@@ -40,7 +53,11 @@ function getIDBItem(type: IDBItemType): (alias: string) => Promise<IDBDatabase |
     const withoutAtSign = alias.substr(1);
     if (map.has(withoutAtSign)) {
       log.end();
-      return Promise.resolve(map.get(withoutAtSign) as IDBDatabase | IDBObjectStore);
+      let result: string | IDBObjectStore | IDBDatabase | undefined = map.get(withoutAtSign);
+      if (typeof result === 'string') {
+        result = DATABASES.get(result);
+      }
+      return Promise.resolve(result as IDBObjectStore);
     } else {
       error = new Error(`could not find ${type} with alias ${alias}`);
       log.error(error).end();

--- a/libs/cypress-indexeddb/src/lib/cypress-indexeddb.ts
+++ b/libs/cypress-indexeddb/src/lib/cypress-indexeddb.ts
@@ -1,20 +1,24 @@
 import { getDatabase, getStore, overrideAs } from './alias-setup';
 import { createObjectStore } from './create-object-store';
 import { deleteDatabase } from './delete-database';
-import { createItem, deleteItem, readItem, updateItem } from './object-store-CRUD';
+import { addItem, createItem, deleteItem, readItem, updateItem } from './object-store-CRUD';
+import { entries, keys } from './object-store-metadata';
 import { openIndexedDb } from './open-database';
 
 function setupIDBHelpers(): void {
   Cypress.Commands.overwrite('as', overrideAs);
-  Cypress.Commands.add('clearIndexedDb', deleteDatabase);
-  Cypress.Commands.add('openIndexedDb', openIndexedDb);
-  Cypress.Commands.add('getIndexedDb', getDatabase);
+  Cypress.Commands.add(`clearIndexedDb`, deleteDatabase);
+  Cypress.Commands.add(`openIndexedDb`, openIndexedDb);
+  Cypress.Commands.add(`getIndexedDb`, getDatabase);
   Cypress.Commands.add(`createObjectStore`, { prevSubject: true }, createObjectStore);
-  Cypress.Commands.add('getStore', getStore);
+  Cypress.Commands.add(`getStore`, getStore);
   Cypress.Commands.add(`createItem`, { prevSubject: true }, createItem);
   Cypress.Commands.add(`updateItem`, { prevSubject: true }, updateItem);
   Cypress.Commands.add(`deleteItem`, { prevSubject: true }, deleteItem);
   Cypress.Commands.add(`readItem`, { prevSubject: true }, readItem);
+  Cypress.Commands.add(`addItem`, { prevSubject: true }, addItem);
+  Cypress.Commands.add(`keys`, { prevSubject: true }, keys);
+  Cypress.Commands.add(`entries`, { prevSubject: true }, entries);
 }
 
 setupIDBHelpers();

--- a/libs/cypress-indexeddb/src/lib/helpers.ts
+++ b/libs/cypress-indexeddb/src/lib/helpers.ts
@@ -5,3 +5,23 @@ export function isIDBObjectStore(subject: unknown): subject is IDBObjectStore {
 export function isIDBDatabase(subject: unknown): subject is IDBDatabase {
   return typeof subject === 'object' && subject?.constructor?.name === 'IDBDatabase';
 }
+
+/**
+ * Gets the array of arguments for the certain indexedDb operations (get, put, delete, add);
+ * The 'put' operation gets two arguments, and if there is no key provided the 'add' method receives the value
+ * @param key - string or null. Null if it is an add operation
+ * @param value - the value needs to be stored
+ */
+export function getCommandArguments<T>(
+  key: string | null,
+  value: T | undefined
+): [T, string] | [string] | [T] {
+  return key ? getCommandArgumentsBasedOnValue(key, value) : [value as T];
+}
+
+function getCommandArgumentsBasedOnValue<T>(
+  key: string,
+  value: T | undefined
+): [T, string] | [string] {
+  return value ? [value, key] : [key];
+}

--- a/libs/cypress-indexeddb/src/lib/object-store-CRUD.ts
+++ b/libs/cypress-indexeddb/src/lib/object-store-CRUD.ts
@@ -1,10 +1,10 @@
-import { isIDBObjectStore } from './helpers';
+import { getCommandArguments, isIDBObjectStore } from './helpers';
 import { createDatabaseConnection } from './open-database';
 import Log = Cypress.Log;
 
-type SetItemOperation = 'create' | 'update';
+type SetItemOperation = 'create' | 'update' | 'add';
 type ReadDeleteOperation = 'read' | 'delete';
-type StoreOperation = keyof Pick<IDBObjectStore, 'get' | 'put' | 'delete'>;
+type StoreOperation = keyof Pick<IDBObjectStore, 'get' | 'put' | 'delete' | 'add'>;
 type ConsolePropObject = {
   key: string;
   value?: unknown;
@@ -22,8 +22,8 @@ export function readItem<T>(store: IDBObjectStore, key: string): Promise<T> {
     throw error;
   }
   return createDatabaseConnection(store.transaction.db.name)
-    .then((openDb) => makeCreateUpdateDeleteRequest<T>('get', openDb, store, key))
-    .then((result) => {
+    .then((openDb: IDBDatabase) => makeCreateUpdateDeleteRequest<T>('get', openDb, store, key))
+    .then((result: T) => {
       consoleProps.value = result;
       log.end();
       return result as T;
@@ -46,8 +46,10 @@ export function deleteItem(store: IDBObjectStore, key: string): Promise<IDBObjec
     throw error;
   }
   return createDatabaseConnection(store.transaction.db.name)
-    .then((openDb) => makeCreateUpdateDeleteRequest<IDBObjectStore>('delete', openDb, store, key))
-    .then((store) => {
+    .then((openDb: IDBDatabase) =>
+      makeCreateUpdateDeleteRequest<IDBObjectStore>('delete', openDb, store, key)
+    )
+    .then((store: IDBObjectStore) => {
       log.end();
       return store;
     })
@@ -63,7 +65,7 @@ export function createItem(
   key: string,
   value: unknown
 ): Promise<IDBObjectStore> {
-  return setItem('create', store, key, value);
+  return setItem('add', store, key, value);
 }
 
 export function updateItem(
@@ -74,10 +76,14 @@ export function updateItem(
   return setItem('update', store, key, value);
 }
 
+export function addItem(store: IDBObjectStore, value: unknown): Promise<IDBObjectStore> {
+  return setItem('add', store, null, value);
+}
+
 function setItem(
   operation: SetItemOperation,
   store: IDBObjectStore,
-  key: string,
+  key: string | null,
   value: unknown
 ): Promise<IDBObjectStore> {
   const { log, consoleProps } = createCRUDLog(operation, key);
@@ -92,10 +98,16 @@ function setItem(
   }
 
   return createDatabaseConnection(store.transaction.db.name)
-    .then((openDb) =>
-      makeCreateUpdateDeleteRequest<IDBObjectStore, unknown>('put', openDb, store, key, value)
+    .then((openDb: IDBDatabase) =>
+      makeCreateUpdateDeleteRequest<IDBObjectStore, unknown>(
+        key ? 'put' : 'add',
+        openDb,
+        store,
+        key,
+        value
+      )
     )
-    .then((store) => {
+    .then((store: IDBObjectStore) => {
       log.end();
       return store;
     })
@@ -110,10 +122,10 @@ function makeCreateUpdateDeleteRequest<T, O = undefined>(
   operation: StoreOperation,
   db: IDBDatabase,
   store: IDBObjectStore,
-  key: string,
+  key: string | null,
   value?: O
 ): Promise<T> {
-  const commandArguments: [O, string] | [string] = value ? [value, key] : [key];
+  const commandArguments = getCommandArguments(key, value);
   return new Promise((resolve, reject) => {
     const request: IDBRequest = db
       .transaction(store.name, 'readwrite')
@@ -135,10 +147,10 @@ function makeCreateUpdateDeleteRequest<T, O = undefined>(
 
 function createCRUDLog(
   operation: SetItemOperation | ReadDeleteOperation,
-  key: string
+  key: string | null
 ): { log: Log; consoleProps: ConsolePropObject } {
   const consoleProps: ConsolePropObject = {
-    key,
+    key: key || 'no key provided',
   };
   const log = Cypress.log({
     autoEnd: false,

--- a/libs/cypress-indexeddb/src/lib/object-store-metadata.ts
+++ b/libs/cypress-indexeddb/src/lib/object-store-metadata.ts
@@ -1,0 +1,94 @@
+import Log = Cypress.Log;
+import { isIDBObjectStore } from './helpers';
+import { createDatabaseConnection } from './open-database';
+
+type StoreOperation = keyof Pick<IDBObjectStore, 'getAllKeys' | 'getAll'>;
+type ConsolePropObject = {
+  result?: unknown;
+  error?: Error;
+};
+
+export function keys(store: IDBObjectStore): Promise<IDBValidKey[]> {
+  const { log, consoleProps } = createMetadataLog('keys');
+  if (!isIDBObjectStore(store)) {
+    const error = new Error(
+      `You tried to use the 'keys' method without calling 'getObjectStore' first`
+    );
+    consoleProps.error = error;
+    log.error(error).end();
+    throw error;
+  }
+  return createDatabaseConnection(store.transaction.db.name)
+    .then((openDb: IDBDatabase) => getMetadata<IDBValidKey>(openDb, store, 'getAllKeys'))
+    .then((result: IDBValidKey[]) => {
+      consoleProps.result = result;
+      log.end();
+      return result;
+    })
+    .catch((e) => {
+      consoleProps.error = e;
+      log.error(e).end();
+      throw e;
+    });
+}
+
+export function entries<T = unknown>(store: IDBObjectStore): Promise<T[]> {
+  const { log, consoleProps } = createMetadataLog('entries');
+  if (!isIDBObjectStore(store)) {
+    const error = new Error(
+      `You tried to use the 'entries' method without calling 'getObjectStore' first`
+    );
+    consoleProps.error = error;
+    log.error(error).end();
+    throw error;
+  }
+  return createDatabaseConnection(store.transaction.db.name)
+    .then((openDb: IDBDatabase) => getMetadata<T>(openDb, store, 'getAll'))
+    .then((result: T[]) => {
+      consoleProps.result = result;
+      log.end();
+      return result;
+    })
+    .catch((e) => {
+      consoleProps.error = e;
+      log.error(e).end();
+      throw e;
+    });
+}
+
+function getMetadata<T>(
+  db: IDBDatabase,
+  store: IDBObjectStore,
+  operation: StoreOperation
+): Promise<T[]> {
+  return new Promise((resolve, reject) => {
+    const request: IDBRequest = db
+      .transaction(store.name, 'readwrite')
+      .objectStore(store.name)
+      [operation]();
+    request.onerror = (e) => {
+      reject(e);
+    };
+    request.onsuccess = () => {
+      request.onerror = () => void 0;
+      db.close();
+      const result = request.result as T[];
+      resolve(result);
+    };
+  });
+}
+
+function createMetadataLog(operation: 'keys' | 'entries'): {
+  log: Log;
+  consoleProps: ConsolePropObject;
+} {
+  const consoleProps: ConsolePropObject = {};
+  const log = Cypress.log({
+    autoEnd: false,
+    type: 'child',
+    name: operation,
+    message: `IDBObjectStore ${operation}`,
+    consoleProps: () => consoleProps,
+  });
+  return { log, consoleProps };
+}

--- a/libs/cypress-indexeddb/src/lib/upgrade-database.ts
+++ b/libs/cypress-indexeddb/src/lib/upgrade-database.ts
@@ -1,3 +1,5 @@
+import { setDatabaseInternal } from './alias-setup';
+
 export function createVersionUpdateDatabaseConnection(
   openDatabase: IDBDatabase
 ): Promise<IDBDatabase> {
@@ -18,8 +20,11 @@ export function createVersionUpdateDatabaseConnection(
   });
   return new Promise<IDBDatabase>((resolve, reject) => {
     openDatabase.close();
+    console.warn('openDb', openDatabase);
     const request: IDBOpenDBRequest = window.indexedDB.open(databaseName, openDatabase.version + 1);
+    console.warn('update db request', request);
     request.onerror = (e: Event) => {
+      console.warn('error');
       error = e;
       log.error(e as unknown as Error).end();
       reject(e);
@@ -28,6 +33,7 @@ export function createVersionUpdateDatabaseConnection(
       request.onerror = () => void 0;
       const db = (e.target as any).result as IDBDatabase;
       databaseVersion = db.version;
+      setDatabaseInternal(databaseName, db);
       log.end();
       resolve(db);
     };


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
This PR includes:
 - Added the `addItem`, `keys` and `entries` methods.
 - Added the options parameter to the `createObjectStore` command to support stores with autoIncrement enabled.
 - Fixed a bug where creating multiple object stores on one database caused the `createObjectStore` method to timeout
 - Updated the documentation
 - Updated the package version for publish

fixes #77 

## Feature

- [X] Implements an existing feature request or change request. Make sure the feature request has been accepted for implementation before opening a PR.
- [X] Related issues linked using `fixes #number`
- [X] The new feature, or the fix is tested with jest and if applicable with cypress
- [X] The code is properly formatted using the project's prettier and eslint settings
- [X] Make sure that everything is properly typed in the code.
- [X] Contribution guidelines are met
- [x] Documentation added
- [x] package version got updated

## Documentation / Examples

- [x] Make sure the linting passes
