### PR TITLE
chore: update copyright year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 ThisDot Inc.
+Copyright (c) 2021-2022 ThisDot Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/apps/showcase/src/app/app.component.html
+++ b/apps/showcase/src/app/app.component.html
@@ -91,5 +91,5 @@
     </mat-sidenav-content>
   </mat-sidenav-container>
 
-  <mat-toolbar class="footer">© This Dot Labs 2021</mat-toolbar>
+  <mat-toolbar class="footer">© This Dot Labs 2022</mat-toolbar>
 </ng-container>


### PR DESCRIPTION
## Chore
- [x] Update copyright year to 2022
## Changes made
- [x] Updated copyright in `LICENSE.md` from `2021` to `2021-2022` based on how I saw Nodejs & Angular's MIT License. (screenshots below)
- [x] Updated copyright in `apps/showcase/src/app/app.component.html` from `2021` to `2022` based on how I saw it on This Dot's website. (screenshot below)

If the format I used is incorrect, I can update this PR or if this update isn't needed I can close this PR.
Thank you! 😄

## Nodejs MIT License
![image](https://user-images.githubusercontent.com/10107412/150987237-0c4ffaf1-4b6b-4097-aa0a-98511a766fb4.png)
## Angular MIT License
![image](https://user-images.githubusercontent.com/10107412/150987686-175451c9-5924-41b5-b5f5-f7722581e198.png)
## This Dot's copyright on website
![image](https://user-images.githubusercontent.com/10107412/150987973-d5b3a714-9e06-4424-87a5-6479375a47da.png)

