### PR TITLE
fix: configure publishable libraries build dependencies

### DIFF
--- a/libs/ng-utils/project.json
+++ b/libs/ng-utils/project.json
@@ -19,6 +19,7 @@
           "tsConfig": "libs/ng-utils/tsconfig.lib.json"
         }
       },
+      "dependsOn": [{ "projects": "dependencies", "target": "build" }],
       "defaultConfiguration": "production"
     },
     "test": {

--- a/libs/route-config/project.json
+++ b/libs/route-config/project.json
@@ -18,6 +18,7 @@
           "tsConfig": "libs/route-config/tsconfig.lib.json"
         }
       },
+      "dependsOn": [{ "projects": "dependencies", "target": "build" }],
       "defaultConfiguration": "production"
     },
     "lint": {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [X] Related issues linked using `fixes #number`
- [x] The new feature, or the fix is tested with jest and if applicable with cypress
- [x] The code is properly formatted using the project's prettier and eslint settings
- [x] Make sure everything is properly typed in the code.
- [x] Contribution guidelines are met



Buildable/Publishable libraries need to have their dependencies built before they can be built.

There are different ways to achieve this in Nx, for example:
- Run build command with --with-deps flag
- Specify the dependsOn configuration on the project.json of the file

We choose the second alternative. Learn more in the [dependsOn docs.](https://nx.dev/configuration/projectjson#dependson)

We only applied this configuration to the `ng-utils` and `route-config` libraries because these are the only libraries with dependencies according to the dependency graph.

![oss-thisdot graph](https://user-images.githubusercontent.com/9338604/177639990-0b50b858-3b8a-4e2b-8133-fe0f966d2119.png)


- [x] Make sure the linting passes


Closes #100 